### PR TITLE
Run linter against Python files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
       - run: npm run lint
       - run: pip install -r requirements.txt
       - run: black --check .
-      - run: pylint *
+      - run: pylint tests/*.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,3 +12,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm run lint
+      - run: pip install -r requirements.txt
+      - run: black --check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,3 +14,4 @@ jobs:
       - run: npm run lint
       - run: pip install -r requirements.txt
       - run: black --check .
+      - run: pylint *

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest-playwright==0.5.2
+black==24.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest-playwright==0.5.2
 black==24.8.0
+pylint==3.3.1

--- a/tests/main_page_test.py
+++ b/tests/main_page_test.py
@@ -4,23 +4,25 @@ import os
 current_working_directory = os.getcwd()
 full_path = "http://localhost:8000"
 
+
 def test_title(page: Page):
     #  Step 1: Navigate to the index.html page
     page.goto(full_path)
 
     #  Step 2: Check the page title
-    expect(page).to_have_title('Integrative Coding Experience')
+    expect(page).to_have_title("Integrative Coding Experience")
+
 
 def test_desired_outcome(page: Page):
     #  Step 1: Navigate to the index.html page
     page.goto(full_path)
-    
+
     # Step 2: Check the page for a spot for desired output
     textbox_locator = page.locator("#output-text")
     assert textbox_locator.is_visible()
 
-def test_student_link_navigates(page: Page):
 
+def test_student_link_navigates(page: Page):
     # This functionality can only truly be tested on a live webpage
     # GitHub pages presents the best environment to do this in.
     # Step 1: Navigate to index.html on github page
@@ -36,7 +38,7 @@ def test_student_link_navigates(page: Page):
     page.context.grant_permissions(["clipboard-write"])
     page.locator("#share").click()
 
-    # Step 5: Checking for Alert 
+    # Step 5: Checking for Alert
     page.locator("#link-display").click()
 
     expect(page.locator("#alert")).to_be_visible()

--- a/tests/main_page_test.py
+++ b/tests/main_page_test.py
@@ -1,44 +1,46 @@
-from playwright.sync_api import Page, expect
-import os
+"""
+Tests for the teacher view of the application
 
-current_working_directory = os.getcwd()
-full_path = "http://localhost:8000"
+These are the end-to-end UI test for index.html
+"""
+
+from playwright.sync_api import Page, expect
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def before_each(page: Page):
+    """Load the page before each test"""
+    page.goto("http://localhost:8000")
 
 
 def test_title(page: Page):
-    #  Step 1: Navigate to the index.html page
-    page.goto(full_path)
+    """Confirm the page has an appropriate title"""
 
-    #  Step 2: Check the page title
     expect(page).to_have_title("Integrative Coding Experience")
 
 
 def test_desired_outcome(page: Page):
-    #  Step 1: Navigate to the index.html page
-    page.goto(full_path)
+    """Confirm that output text is visible"""
 
-    # Step 2: Check the page for a spot for desired output
     textbox_locator = page.locator("#output-text")
     assert textbox_locator.is_visible()
 
 
 def test_student_link_navigates(page: Page):
-    # This functionality can only truly be tested on a live webpage
-    # GitHub pages presents the best environment to do this in.
-    # Step 1: Navigate to index.html on github page
-    page.goto(full_path)
+    """Confirm that student link copies correctly"""
 
-    # Step 2: Input text in input field
+    # Step 1: Input text in input field
     page.locator("#code-area").fill("test input")
 
-    # Step 3: Input text in output field
+    # Step 2: Input text in output field
     page.locator("#output-text").fill("test output")
 
-    # Step 4: Pushing the (share) Button
+    # Step 3: Pushing the (share) Button
     page.context.grant_permissions(["clipboard-write"])
     page.locator("#share").click()
 
-    # Step 5: Checking for Alert
+    # Step 4: Checking for Alert
     page.locator("#link-display").click()
 
     expect(page.locator("#alert")).to_be_visible()

--- a/tests/student_page_test.py
+++ b/tests/student_page_test.py
@@ -1,23 +1,27 @@
-from playwright.sync_api import Page, expect
-import os
+"""
+Tests for the student view of the application
 
-current_working_directory = os.getcwd()
-file_name = "www/student.html"
-full_path = "file://" + os.path.join(current_working_directory, file_name)
+These are the end-to-end UI tests for student.html
+"""
+
+from playwright.sync_api import Page, expect
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def before_each(page: Page):
+    """Load the page before each test"""
+    page.goto("http://localhost:8000/student.html")
 
 
 def test_title(page: Page):
-    #  Step 1: Navigate to the student.html page
-    page.goto(full_path)
+    """Confirm the page has an appropriate title"""
 
-    #  Step 2: Check the page title
     expect(page).to_have_title("Integrative Coding Experience")
 
 
 def test_student_input(page: Page):
-    #  Step 1: Navigate to the student.html page
-    page.goto(full_path)
+    """Confirm that output text is visible"""
 
-    # Step 2: Test that text area is on page
     textarea_locator = page.locator("#output-text")
     assert textarea_locator.is_visible()

--- a/tests/student_page_test.py
+++ b/tests/student_page_test.py
@@ -5,12 +5,14 @@ current_working_directory = os.getcwd()
 file_name = "www/student.html"
 full_path = "file://" + os.path.join(current_working_directory, file_name)
 
+
 def test_title(page: Page):
     #  Step 1: Navigate to the student.html page
     page.goto(full_path)
 
     #  Step 2: Check the page title
-    expect(page).to_have_title('Integrative Coding Experience')
+    expect(page).to_have_title("Integrative Coding Experience")
+
 
 def test_student_input(page: Page):
     #  Step 1: Navigate to the student.html page


### PR DESCRIPTION
This change introduces additional lint checks for our Python files. In particular, it runs [pylint](https://www.pylint.org/) and [black](https://black.readthedocs.io/en/stable/index.html) against our tests directory. The tests were refactored to pass the lint checks.