### PR TITLE
Ensure end button is disabled after page refresh

### DIFF
--- a/www/student.js
+++ b/www/student.js
@@ -50,6 +50,10 @@ let codeWorker = createCodeWorker()
 // get HTML elements
 const runButton = document.querySelector('#run-button')
 const endButton = document.querySelector('#end-button')
+
+// Ensure the end button is disabled by default (firefox bug)
+endButton.disabled = true
+
 const timeDisplayP = document.querySelector('#time-displayed')
 
 // Run code when button pressed.


### PR DESCRIPTION
Fixes bug that makes "End" button enabled after page refresh when python code is running