### PR TITLE
Update CI to test in Firefox and Chromium

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,4 +12,4 @@ jobs:
       - run: pip install pytest-playwright
       - run: python -m playwright install
       - run: cd www && python -m http.server && cd .. &
-      - run: pytest
+      - run: pytest --browser chromium --browser firefox

--- a/tests/main_page_test.py
+++ b/tests/main_page_test.py
@@ -4,7 +4,7 @@ Tests for the teacher view of the application
 These are the end-to-end UI test for index.html
 """
 
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Page, expect, Error
 import pytest
 
 
@@ -37,7 +37,12 @@ def test_student_link_navigates(page: Page):
     page.locator("#output-text").fill("test output")
 
     # Step 3: Pushing the (share) Button
-    page.context.grant_permissions(["clipboard-write"])
+    try:
+        # Acquire clipboard-write. This is only supported and required in Chromium.
+        page.context.grant_permissions(["clipboard-write"])
+    except Error:
+        pass
+
     page.locator("#share").click()
 
     # Step 4: Checking for Alert

--- a/tests/student_page_test.py
+++ b/tests/student_page_test.py
@@ -40,7 +40,7 @@ def test_python_runs(page: Page):
     page.locator("#run-button").click()
 
     # 3. Assert desired output is
-    expect(page.locator("#code-output")).to_have_text("Hello, world!")
+    expect(page.locator("#code-output")).to_have_text("Hello, world!", timeout=10000)
 
 
 def test_buttons_disable(page: Page):


### PR DESCRIPTION
This change enables Playwright tests to be run with both Firefox and Chromium. The tests currently use Chromium only. This should allow us to begin to identify and test for browser-specific issues.

A few minor changes were required in order to run our test suite successfully in Firefox.