### PR TITLE
Add regression test for firefox button state

### DIFF
--- a/tests/student_page_test.py
+++ b/tests/student_page_test.py
@@ -66,3 +66,29 @@ def test_buttons_disable(page: Page):
     # 5. Expect the run button to be enabled, end button to be disabled.
     expect(page.locator("#run-button")).to_be_enabled()
     expect(page.locator("#end-button")).to_be_disabled()
+
+
+def test_buttons_disable_firefox_bug(page: Page):
+    """
+    Test that refreshing the page while the program is running leaves the
+    buttons in appropriate states
+    """
+
+    # 1. Put code in code area
+    textarea_locator = page.locator("#code-area")
+    textarea_locator.fill("while True:\n\tprint(1)")
+
+    # 2. Click Run Button
+    page.locator("#run-button").click()
+
+    # 3. Expect run button to be disabled, end button to be enabled
+    expect(page.locator("#run-button")).to_be_disabled()
+    expect(page.locator("#end-button")).to_be_enabled()
+
+    # 4. Refresh the page. This should kill the looping Python script.
+
+    page.evaluate("window.location.reload()")
+
+    # 5. Expect run button to be enabled, end button to be disabled
+    expect(page.locator("#run-button")).to_be_enabled()
+    expect(page.locator("#end-button")).to_be_disabled()

--- a/www/student.js
+++ b/www/student.js
@@ -60,6 +60,9 @@ let codeWorker = createCodeWorker()
 const runButton = document.querySelector('#run-button')
 const endButton = document.querySelector('#end-button')
 
+// Ensure the end button is disabled by default (firefox bug)
+endButton.disabled = true
+
 const timeDisplayP = document.querySelector('#time-displayed')
 
 // Run code when button pressed.

--- a/www/student.js
+++ b/www/student.js
@@ -60,9 +60,6 @@ let codeWorker = createCodeWorker()
 const runButton = document.querySelector('#run-button')
 const endButton = document.querySelector('#end-button')
 
-// Ensure the end button is disabled by default (firefox bug)
-endButton.disabled = true
-
 const timeDisplayP = document.querySelector('#time-displayed')
 
 // Run code when button pressed.


### PR DESCRIPTION
There was an issue that caused buttons to be improperly disabled when refreshing the page while a Python script was running. This PR adds a test to confirm that this bug is fixed.