### PR TITLE
Increase timeout for testing code output

### DIFF
--- a/tests/student_page_test.py
+++ b/tests/student_page_test.py
@@ -34,7 +34,7 @@ def test_python_runs(page: Page):
     page.locator("#run-button").click()
 
     # 3. Assert desired output is
-    expect(page.locator("#code-output")).to_have_text("Hello, world!", timeout=10000)
+    expect(page.locator("#code-output")).to_have_text("Hello, world!", timeout=20000)
 
 
 def test_buttons_disable(page: Page):
@@ -82,7 +82,7 @@ def test_check_output_correct(page: Page):
 
     # 4. Check Output
     expect(page.locator("#check-code-result")).to_contain_text(
-        "Correct   ✔", timeout=10000
+        "Correct   ✔", timeout=20000
     )
 
 
@@ -106,7 +106,7 @@ def test_check_output_incorrect(page: Page):
 
     # 4. Check Output
     expect(page.locator("#check-code-result")).to_contain_text(
-        "Does not match target output   ❌", timeout=10000
+        "Does not match target output   ❌", timeout=20000
     )
 
 
@@ -147,4 +147,4 @@ def test_error_message_displayed(page: Page):
 
     # Use expect to wait until the error message appears
     error_locator = page.locator("#code-output")
-    expect(error_locator).to_contain_text("Error:", timeout=10000)
+    expect(error_locator).to_contain_text("Error:", timeout=20000)


### PR DESCRIPTION
This change doubles the time waiting for code output. This may help to alleviate flaky test behavior.