### PR TITLE
Disable autocomplete to prevent persisting disabled state

### DIFF
--- a/www/student.html
+++ b/www/student.html
@@ -18,8 +18,8 @@
         <textarea id="code-area"></textarea>
       </div>
       <div id="output-displays">
-        <button id="run-button">Run</button>
-        <button id="end-button" disabled>End</button>
+        <button id="run-button" autocomplete="off">Run</button>
+        <button id="end-button" autocomplete="off" disabled>End</button>
         <p id="time-displayed"></p>
         <h1>Code Output:</h1>
         <textarea id="code-output"></textarea>

--- a/www/student.js
+++ b/www/student.js
@@ -60,9 +60,6 @@ let codeWorker = createCodeWorker()
 const runButton = document.querySelector('#run-button')
 const endButton = document.querySelector('#end-button')
 
-// Ensure the end button is disabled by default (firefox bug)
-endButton.disabled = true
-
 const timeDisplayP = document.querySelector('#time-displayed')
 
 // Run code when button pressed.


### PR DESCRIPTION
The intent of this change is to address flakiness in Firefox tests. We are currently working around an issue in Firefox that causes button `disabled` state to be persisted by autocomplete. Rather than working around this issue using JS, this change disables autocomplete directly.