### PR TITLE
Remove unused Pyodide script

### DIFF
--- a/www/student.html
+++ b/www/student.html
@@ -6,7 +6,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="stylesheet" href="style.css" />
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.26.3/full/pyodide.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
This change removes a duplicate request to load Pyodide. `worker.js` loads this separately, and it is never used in the context that I have removed.