### PR TITLE
Fast-forward when waiting for infinite loop

### DIFF
--- a/tests/student_page_test.py
+++ b/tests/student_page_test.py
@@ -162,6 +162,8 @@ def test_infinite_loop_error_message(page: Page):
 
     page.locator("#run-button").click()
 
+    page.clock.run_for(30000)
+
     # Wait for the error message to appear in the output
     error_locator = page.locator("#code-output")
 


### PR DESCRIPTION
This change fast-forwards the clock in Playwright rather than waiting for the full 20s for our infinite loop detection to kick in. This change roughly halves the time needed to run the full test suite.