### PR TITLE
Remove axios dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "lint-fix": "npx prettier --write ."
   },
   "dependencies": {
-    "axios": "^1.7.7",
     "prettier": "^3.3.3"
   }
 }


### PR DESCRIPTION
This change removes the `axios` dependency from package.json. This is unused as far as I can tell.