### PR TITLE
Remove db context teardown

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,10 +1,10 @@
 """
-    Flask server for running the API for the database and web server for the application. 
+    Flask server for running the API for the database and web server for the application.
 
     Currently provides routes to all static files in the `www` directory
 """
 
-from flask import Flask, g
+from flask import Flask
 
 from blueprints.serve_static import serve_static
 from blueprints.api import api
@@ -32,15 +32,5 @@ def create_app(testing=False):
     # Register blueprints
     app.register_blueprint(serve_static)
     app.register_blueprint(api, url_prefix="/api")
-
-    # Close database connections when the app context closes.
-    @app.teardown_appcontext
-    def close_db(exception):
-        # pylint: disable=unused-argument
-        """Closes the connection to the database when the app context is destroyed."""
-        db = getattr(g, "_database", None)
-        if db is not None:
-            db.commit()
-            db.close()
 
     return app


### PR DESCRIPTION
This change removes the db context teardown when closing the app. The db context is now managed per request and this code served no purpose.